### PR TITLE
Use QRegularExpression.

### DIFF
--- a/cutter-plugin/YaraAddDialog.cpp
+++ b/cutter-plugin/YaraAddDialog.cpp
@@ -24,7 +24,7 @@ YaraAddDialog::YaraAddDialog(RVA offset, QWidget *parent)
         QString name = QString(flag->name);
         if (name.startsWith("str.")) {
             name = name.replace("str.", "");
-            name = name.replace(QRegExp("[^A-Za-z0-9_]+"), "");
+            name = name.replace(QRegularExpression("[^A-Za-z0-9_]+"), "");
             if (!name.isEmpty()) {
                 ui->nameEdit->setText(name);
             }


### PR DESCRIPTION
QRegExp has been replaced by QRegularExpression in latest versions of Qt. Required for Qt6 support.

QRegularExpression was introduced in Qt5. And the Qt6 made QRegExp deprecated. In theory it's still available in the qt5compat library, but since the new API was already introduced in Qt5 it's simpler to just use that.