### PR TITLE
Incorrect usage of CutterCore::core.

### DIFF
--- a/cutter-plugin/YaraAddDialog.cpp
+++ b/cutter-plugin/YaraAddDialog.cpp
@@ -19,7 +19,8 @@ YaraAddDialog::YaraAddDialog(RVA offset, QWidget *parent)
     ui->sizeEdit->setText("1");
     ui->nameEdit->setText("placeholder");
 
-    RzFlagItem *flag = rz_flag_get_i(Core()->core()->flags, offset);
+    RzCoreLocked core(Core());
+    RzFlagItem *flag = rz_flag_get_i(core->flags, offset);
     if (flag) {
         QString name = QString(flag->name);
         if (name.startsWith("str.")) {


### PR DESCRIPTION
Can't hold on to rizin objects after temporary RzCoreLocked is destroyed.

Caught using https://github.com/rizinorg/cutter/pull/3473