### PR TITLE
Use C++20 for yara Cutter plugin

### DIFF
--- a/cutter-plugin/CMakeLists.txt
+++ b/cutter-plugin/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(cutter-yara-plugin)
 
+set(CMAKE_CXX_STANDARD 20)
 
 set(CUTTER_INSTALL_PLUGDIR "share/rizin/cutter/plugins/native" CACHE STRING "Directory to install Cutter plugin into")
 set(RIZIN_INSTALL_PLUGDIR "lib/rizin/plugins" CACHE STRING "Directory where to find librz_yara")


### PR DESCRIPTION
This pr uses C++20 for the build to fix errors of the following form in rizinorg/cutter#3554:

<img width="979" height="100" alt="yara-c++20" src="https://github.com/user-attachments/assets/a8ea925d-abaf-4f02-b174-9be5e3c7701a" />

(https://github.com/rizinorg/cutter/actions/runs/22182888162/job/64148575654#step:9:11985)

The reasoning for the change is basically the same as in https://github.com/rizinorg/jsdec/pull/67#issuecomment-3914066220.