### PR TITLE
ht: Use `size` instead of `count`

### DIFF
--- a/src/yara_generator.c
+++ b/src/yara_generator.c
@@ -298,7 +298,7 @@ RZ_API char *rz_yara_create_rule_from_bytes(RZ_NONNULL RzCore *core, RZ_NULLABLE
 	}
 	rz_strbuf_append(sb, "\n{\n");
 
-	if (metadata && metadata->count > 0) {
+	if (metadata && metadata->size > 0) {
 		rz_strbuf_append(sb, "\tmeta:\n");
 		ht_sp_foreach(metadata, (HtSPForeachCallback)add_metadata, &cd);
 		rz_strbuf_append(sb, "\n");


### PR DESCRIPTION
This pr changes `metadata->count` to `metadata->size` in accordance with https://github.com/rizinorg/rizin/commit/95f94ae25852cd9bbc1bafd23234cf3ff4e02ffa#diff-bf33ca6d09dc7030c91bd769f2b427c1f9688babf4ffa32e1dc5d93dd36b29d2 (green line 249), and fixes the following error:

<img width="935" height="99" alt="yara-count" src="https://github.com/user-attachments/assets/71f94031-d844-4058-b173-bb3ec1ec42df" />

(https://github.com/rizinorg/cutter/actions/runs/22907938425/job/66471831717?pr=3571#step:10:9378)